### PR TITLE
perf: reduce allocations and boxing

### DIFF
--- a/ConsoleDemo/Program.cs
+++ b/ConsoleDemo/Program.cs
@@ -101,21 +101,21 @@ case ModelType.Classification:
 case ModelType.ObjectDetection:
     {
         var result = yolo.RunObjectDetection(image, 0.23, 0.7);
-        labels = result.Select(x => x.Label).ToList();
+        labels = result.Select(x => x.Detection.Label).ToList();
         resultImage = image.Draw(result);
         break;
     }
 case ModelType.ObbDetection:
     {
         var result = yolo.RunObbDetection(image, 0.23, 0.7);
-        labels = result.Select(x => x.Label).ToList();
+        labels = result.Select(x => x.Detection.Label).ToList();
         resultImage = image.Draw(result);
         break;
     }
 case ModelType.Segmentation:
     {
         var result = yolo.RunSegmentation(image, 0.23, 0.65, 0.7);
-        labels = result.Select(x => x.Label).ToList();
+        labels = result.Select(x => x.Detection.Label).ToList();
 
         resultImage = image.Draw(result);
         break;
@@ -123,7 +123,7 @@ case ModelType.Segmentation:
 case ModelType.PoseEstimation:
     {
         var result = yolo.RunPoseEstimation(image, 0.23, 0.7);
-        labels = result.Select(x => x.Label).ToList();
+        labels = result.Select(x => x.Detection.Label).ToList();
         resultImage = image.Draw(result, CustomKeyPointColorMap.KeyPointOptions);
         break;
     }
@@ -188,7 +188,7 @@ Console.WriteLine();
 Console.WriteLine("Complete!");
 };
 
-Dictionary<int, List<ObjectDetection>> detections = yolo.RunObjectDetection(videoOptions, 0.25);
+Dictionary<int, ObjectDetection[]> detections = yolo.RunObjectDetection(videoOptions, 0.25);
 Console.WriteLine();
 }
 

--- a/YoloDotNet/Extensions/CommonExtension.cs
+++ b/YoloDotNet/Extensions/CommonExtension.cs
@@ -40,10 +40,10 @@
             => [.. typeof(T) switch
             {
                 Type t when t == typeof(Classification) => result.Cast<Classification>().Where(x => filterClasses.Contains(x.Label)).Cast<T>(),
-                Type t when t == typeof(ObjectDetection) => result.Cast<ObjectDetection>().Where(x => filterClasses.Contains(x.Label.Name)).Cast<T>(),
-                Type t when t == typeof(OBBDetection) => result.Cast<OBBDetection>().Where(x => filterClasses.Contains(x.Label.Name)).Cast<T>(),
-                Type t when t == typeof(PoseEstimation) => result.Cast<PoseEstimation>().Where(x => filterClasses.Contains(x.Label.Name)).Cast<T>(),
-                Type t when t == typeof(Segmentation) => result.Cast<Segmentation>().Where(x => filterClasses.Contains(x.Label.Name)).Cast<T>(),
+                Type t when t == typeof(ObjectDetection) => result.Cast<ObjectDetection>().Where(x => filterClasses.Contains(x.Detection.Label.Name)).Cast<T>(),
+                Type t when t == typeof(OBBDetection) => result.Cast<OBBDetection>().Where(x => filterClasses.Contains(x.Detection.Label.Name)).Cast<T>(),
+                Type t when t == typeof(PoseEstimation) => result.Cast<PoseEstimation>().Where(x => filterClasses.Contains(x.Detection.Label.Name)).Cast<T>(),
+                Type t when t == typeof(Segmentation) => result.Cast<Segmentation>().Where(x => filterClasses.Contains(x.Detection.Label.Name)).Cast<T>(),
                 _ => throw new ArgumentException("Invalid type", nameof(result))
             }];
     }

--- a/YoloDotNet/Extensions/ImageExtension.cs
+++ b/YoloDotNet/Extensions/ImageExtension.cs
@@ -18,7 +18,7 @@
         /// <param name="objectDetections">An enumerable collection of objects representing the detected items.</param>
         /// <param name="drawConfidence">A boolean indicating whether to include confidence percentages in the drawn labels.</param>
         public static SKImage Draw(this SKImage image, IEnumerable<ObjectDetection>? objectDetections, bool drawConfidence = true)
-            => image.DrawBoundingBoxes(objectDetections, drawConfidence);
+            => image.DrawBoundingBoxes(objectDetections?.Select(x => x.Detection), drawConfidence);
 
 
         /// <summary>
@@ -292,7 +292,7 @@
                 Parallel.ForEach(segmentations, options, segmentation =>
                 {
                     // Define the overlay color
-                    var color = HexToRgbaSkia(segmentation.Label.Color, ImageConfig.SEGMENTATION_MASK_OPACITY);
+                    var color = HexToRgbaSkia(segmentation.Detection.Label.Color, ImageConfig.SEGMENTATION_MASK_OPACITY);
 
                     var pixelSpan = segmentation.SegmentedPixels.AsSpan();
 
@@ -334,8 +334,8 @@
             return draw switch
             {
                 DrawSegment.PixelMaskOnly => SKImage.FromBitmap(bitmap),
-                DrawSegment.BoundingBoxOnly => SKImage.FromBitmap(bitmap).DrawBoundingBoxes(segmentations, drawConfidence),
-                _ => SKImage.FromBitmap(bitmap).DrawBoundingBoxes(segmentations, drawConfidence)
+                DrawSegment.BoundingBoxOnly => SKImage.FromBitmap(bitmap).DrawBoundingBoxes(segmentations.Select(x => x.Detection), drawConfidence),
+                _ => SKImage.FromBitmap(bitmap).DrawBoundingBoxes(segmentations.Select(x => x.Detection), drawConfidence)
             };
         }
 
@@ -406,7 +406,7 @@
             }
 
             if (poseOptions.DrawBoundingBox)
-                return surface.Snapshot().DrawBoundingBoxes(poseEstimations, drawConfidence);
+                return surface.Snapshot().DrawBoundingBoxes(poseEstimations.Select(x => x.Detection), drawConfidence);
 
             return surface.Snapshot();
         }
@@ -417,7 +417,7 @@
         /// <param name="image">The image on which to draw bounding boxes.</param>
         /// <param name="detections">An enumerable collection of objects representing the detected items.</param>
         /// <param name="drawConfidence">A boolean indicating whether to include confidence percentages in the drawn labels.</param>
-        private static SKImage DrawBoundingBoxes(this SKImage image, IEnumerable<IDetection>? detections, bool drawConfidence)
+        private static SKImage DrawBoundingBoxes(this SKImage image, IEnumerable<Detection>? detections, bool drawConfidence)
         {
             ArgumentNullException.ThrowIfNull(detections);
 
@@ -546,11 +546,11 @@
 
             foreach (var detection in detections)
             {
-                var box = detection.BoundingBox;
+                var box = detection.Detection.BoundingBox;
                 var radians = detection.OrientationAngle;
 
-                var boxColor = HexToRgbaSkia(detection.Label.Color, labelBoxAlpha);
-                var labelText = LabelText(detection.Label.Name, detection.Confidence, drawConfidence);
+                var boxColor = HexToRgbaSkia(detection.Detection.Label.Color, labelBoxAlpha);
+                var labelText = LabelText(detection.Detection.Label.Name, detection.Detection.Confidence, drawConfidence);
                 //var labelWidth = (int)paintText.MeasureText(labelText);
                 var labelWidth = (int)font.MeasureText(labelText);
 

--- a/YoloDotNet/Models/Classification.cs
+++ b/YoloDotNet/Models/Classification.cs
@@ -3,8 +3,14 @@
     /// <summary>
     /// Represents the result of image classification
     /// </summary>
-    public class Classification
+    public struct Classification
     {
+        public Classification(string label, double confidence)
+        {
+            this.Label = label;
+            this.Confidence = confidence;
+        }
+
         /// <summary>
         /// Label of classified image.
         /// </summary>

--- a/YoloDotNet/Models/Detection.cs
+++ b/YoloDotNet/Models/Detection.cs
@@ -1,0 +1,27 @@
+﻿namespace YoloDotNet.Models
+{
+    public struct Detection
+    {
+        public Detection(LabelModel label, double confidence, SKRectI boundingBox)
+        {
+            Label = label;
+            Confidence = confidence;
+            BoundingBox = boundingBox;
+        }
+
+        /// <summary>
+        /// Label information associated with the detected object.
+        /// </summary>
+        public LabelModel Label { get; }
+
+        /// <summary>
+        /// Confidence score of the detected object.
+        /// </summary>
+        public double Confidence { get; }
+
+        /// <summary>
+        /// Rectangle defining the region of interest (bounding box) of the detected object.
+        /// </summary>
+        public SKRectI BoundingBox { get; }
+    }
+}

--- a/YoloDotNet/Models/IDetection.cs
+++ b/YoloDotNet/Models/IDetection.cs
@@ -1,9 +1,0 @@
-﻿namespace YoloDotNet.Models
-{
-    public interface IDetection
-    {
-        LabelModel Label { get; init; }
-        double Confidence { get; init; }
-        SKRectI BoundingBox { get; init; }
-    }
-}

--- a/YoloDotNet/Models/KeyPoint.cs
+++ b/YoloDotNet/Models/KeyPoint.cs
@@ -1,4 +1,17 @@
 ﻿namespace YoloDotNet.Models
 {
-    public record KeyPoint(int X, int Y, double Confidence);
+    public struct KeyPoint
+    {
+        public KeyPoint(int x, int y, double confidence)
+        {
+            this.X = x;
+            this.Y = y;
+            this.Confidence = confidence;
+        }
+
+        public int X { get; }
+        public int Y { get; }
+        public double Confidence { get; }
+    }
+
 }

--- a/YoloDotNet/Models/LabelModel.cs
+++ b/YoloDotNet/Models/LabelModel.cs
@@ -3,8 +3,15 @@
     /// <summary>
     /// Represents a label with its associated color in hexadecimal format.
     /// </summary>
-    public record LabelModel
+    public struct LabelModel
     {
+        public LabelModel(int index, string name, string color)
+        {
+            this.Index = index;
+            this.Name = name;
+            this.Color = color;
+        }
+
         /// <summary>
         /// Label index
         /// </summary>

--- a/YoloDotNet/Models/OBBDetection.cs
+++ b/YoloDotNet/Models/OBBDetection.cs
@@ -3,22 +3,15 @@
     /// <summary>
     /// Represents the result of object detection, including label information, confidence score, and bounding box.
     /// </summary>
-    public class OBBDetection : IDetection
+    public struct OBBDetection
     {
-        /// <summary>
-        /// Label information associated with the detected object.
-        /// </summary>
-        public LabelModel Label { get; init; } = new();
+        public OBBDetection(Detection detection, float orientationAngle)
+        {
+            Detection = detection;
+            OrientationAngle = orientationAngle;
+        }
 
-        /// <summary>
-        /// Confidence score of the detected object.
-        /// </summary>
-        public double Confidence { get; init; }
-
-        /// <summary>
-        /// Rectangle defining the region of interest (bounding box) of the detected object.
-        /// </summary>
-        public SKRectI BoundingBox { get; init; }
+        public Detection Detection { get; }
 
         /// <summary>
         /// Orientation angle of bounding box

--- a/YoloDotNet/Models/ObjectDetection.cs
+++ b/YoloDotNet/Models/ObjectDetection.cs
@@ -3,22 +3,14 @@
     /// <summary>
     /// Represents the result of object detection, including label information, confidence score, and bounding box.
     /// </summary>
-    public class ObjectDetection : IDetection
+    public struct ObjectDetection
     {
-        /// <summary>
-        /// Label information associated with the detected object.
-        /// </summary>
-        public LabelModel Label { get; init; } = new();
+        public ObjectDetection(Detection detection)
+        {
+            Detection = detection;
+        }
 
-        /// <summary>
-        /// Confidence score of the detected object.
-        /// </summary>
-        public double Confidence { get; init; }
-
-        /// <summary>
-        /// Rectangle defining the region of interest (bounding box) of the detected object.
-        /// </summary>
-        public SKRectI BoundingBox { get; init; }
+        public Detection Detection { get; }
 
     }
 }

--- a/YoloDotNet/Models/ObjectResult.cs
+++ b/YoloDotNet/Models/ObjectResult.cs
@@ -1,4 +1,6 @@
-﻿namespace YoloDotNet.Models
+﻿using System.Reflection.Emit;
+
+namespace YoloDotNet.Models
 {
     public class ObjectResult
     {
@@ -43,36 +45,15 @@
         public float OrientationAngle { get; set; }
 
         #region Mapping methods
-        public static explicit operator ObjectDetection(ObjectResult result) => new()
-        {
-            Label = result.Label,
-            Confidence = result.Confidence,
-            BoundingBox = result.BoundingBox
-        };
 
-        public static explicit operator OBBDetection(ObjectResult result) => new()
-        {
-            Label = result.Label,
-            Confidence = result.Confidence,
-            BoundingBox = result.BoundingBox,
-            OrientationAngle = result.OrientationAngle
-        };
+        public static explicit operator ObjectDetection(ObjectResult result) => new(detection: new Detection(label: result.Label, confidence: result.Confidence, boundingBox: result.BoundingBox));
 
-        public static explicit operator Segmentation(ObjectResult result) => new()
-        {
-            Label = result.Label,
-            Confidence = result.Confidence,
-            BoundingBox = result.BoundingBox,
-            SegmentedPixels = result.SegmentedPixels
-        };
+        public static explicit operator OBBDetection(ObjectResult result) => new(detection: new Detection(label: result.Label, confidence: result.Confidence, boundingBox: result.BoundingBox), orientationAngle: result.OrientationAngle);
 
-        public static explicit operator PoseEstimation(ObjectResult result) => new()
-        {
-            Label = result.Label,
-            Confidence = result.Confidence,
-            BoundingBox = result.BoundingBox,
-            KeyPoints = result.KeyPoints
-        };
+        public static explicit operator Segmentation(ObjectResult result) => new(detection: new Detection(label: result.Label, confidence: result.Confidence, boundingBox: result.BoundingBox), segmentedPixels: result.SegmentedPixels);
+
+        public static explicit operator PoseEstimation(ObjectResult result) => new(detection: new Detection(label: result.Label, confidence: result.Confidence, boundingBox: result.BoundingBox), keyPoints: result.KeyPoints);
+
         #endregion
     }
 }

--- a/YoloDotNet/Models/PoseEstimation.cs
+++ b/YoloDotNet/Models/PoseEstimation.cs
@@ -1,21 +1,14 @@
 ﻿namespace YoloDotNet.Models
 {
-    public class PoseEstimation : IDetection
+    public struct PoseEstimation
     {
-        /// <summary>
-        /// Label information associated with the detected object.
-        /// </summary>
-        public LabelModel Label { get; init; } = new();
+        public PoseEstimation(Detection detection, KeyPoint[] keyPoints)
+        {
+            Detection = detection;
+            KeyPoints = keyPoints;
+        }
 
-        /// <summary>
-        /// Confidence score of the detected object.
-        /// </summary>
-        public double Confidence { get; init; }
-
-        /// <summary>
-        /// Rectangle defining the region of interest (bounding box) of the detected object.
-        /// </summary>
-        public SKRectI BoundingBox { get; init; }
+        public Detection Detection { get; }
 
         /// <summary>
         /// Keypoints with x, y coordinates and confidence score

--- a/YoloDotNet/Models/Segmentation.cs
+++ b/YoloDotNet/Models/Segmentation.cs
@@ -1,21 +1,14 @@
 ﻿namespace YoloDotNet.Models
 {
-    public class Segmentation : IDetection
+    public struct Segmentation
     {
-        /// <summary>
-        /// Label information associated with the detected object.
-        /// </summary>
-        public LabelModel Label { get; init; } = new();
+        public Segmentation(Detection detection, Pixel[] segmentedPixels)
+        {
+            Detection = detection;
+            SegmentedPixels = segmentedPixels;
+        }
 
-        /// <summary>
-        /// Confidence score of the detected object.
-        /// </summary>
-        public double Confidence { get; init; }
-
-        /// <summary>
-        /// Rectangle defining the region of interest (bounding box) of the detected object.
-        /// </summary>
-        public SKRectI BoundingBox { get; init; }
+        public Detection Detection { get; }
 
         /// <summary>
         /// Segmentated pixels (x,y) with the pixel confidence value

--- a/YoloDotNet/Modules/12/ClassificationModuleV12.cs
+++ b/YoloDotNet/Modules/12/ClassificationModuleV12.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<Classification> ProcessImage(SKImage image, double classes, double pixelConfidence,double iou)
+        public Classification[] ProcessImage(SKImage image, double classes, double pixelConfidence,double iou)
             => _classificationModuleV8.ProcessImage(image, classes, pixelConfidence, iou);
 
-        public Dictionary<int, List<Classification>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, Classification[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/12/OBBDetectionModuleV12.cs
+++ b/YoloDotNet/Modules/12/OBBDetectionModuleV12.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<OBBDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public OBBDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
             => _obbDetectionModuleV8.ProcessImage(image, confidence, pixelConfidence, iou);
 
-        public Dictionary<int, List<OBBDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, OBBDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/12/ObjectDetectionModuleV12.cs
+++ b/YoloDotNet/Modules/12/ObjectDetectionModuleV12.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<ObjectDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public ObjectDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
             => _objectDetectionModuleV8.ProcessImage(image, confidence, pixelConfidence, iou);
 
-        public Dictionary<int, List<ObjectDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, ObjectDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         private void SubscribeToVideoEvents()

--- a/YoloDotNet/Modules/12/PoseEstimationModuleV12.cs
+++ b/YoloDotNet/Modules/12/PoseEstimationModuleV12.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<PoseEstimation> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public PoseEstimation[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
             => _poseEstimationModuleV8.ProcessImage(image, confidence, pixelConfidence, iou);
 
-        public Dictionary<int, List<PoseEstimation>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, PoseEstimation[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/12/SegmentationModuleV12.cs
+++ b/YoloDotNet/Modules/12/SegmentationModuleV12.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<Segmentation> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public Segmentation[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
             => _segmentationModuleV8.ProcessImage(image, confidence, pixelConfidence, iou);
 
-        public Dictionary<int, List<Segmentation>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, Segmentation[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/Interfaces/IClassificationModule.cs
+++ b/YoloDotNet/Modules/Interfaces/IClassificationModule.cs
@@ -2,7 +2,7 @@
 {
     public interface IClassificationModule : IModule
     {
-        List<Classification> ProcessImage(SKImage image, double classes, double pixelConfidence, double iou);
-        Dictionary<int, List<Classification>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou);
+        Classification[] ProcessImage(SKImage image, double classes, double pixelConfidence, double iou);
+        Dictionary<int, Classification[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou);
     }
 }

--- a/YoloDotNet/Modules/Interfaces/IOBBDetectionModule.cs
+++ b/YoloDotNet/Modules/Interfaces/IOBBDetectionModule.cs
@@ -2,7 +2,7 @@
 {
     internal interface IOBBDetectionModule : IModule
     {
-        List<OBBDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence,double iou);
-        Dictionary<int, List<OBBDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence,double iou);
+        OBBDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence,double iou);
+        Dictionary<int, OBBDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence,double iou);
     }
 }

--- a/YoloDotNet/Modules/Interfaces/IObjectDetectionModule.cs
+++ b/YoloDotNet/Modules/Interfaces/IObjectDetectionModule.cs
@@ -2,7 +2,7 @@
 {
     public interface IObjectDetectionModule : IModule
     {
-        List<ObjectDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence,double iou);
-        Dictionary<int, List<ObjectDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou);
+        ObjectDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence,double iou);
+        Dictionary<int, ObjectDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou);
     }
 }

--- a/YoloDotNet/Modules/Interfaces/IPoseEstimationModule.cs
+++ b/YoloDotNet/Modules/Interfaces/IPoseEstimationModule.cs
@@ -2,7 +2,7 @@
 {
     internal interface IPoseEstimationModule : IModule
     {
-        List<PoseEstimation> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou);
-        Dictionary<int, List<PoseEstimation>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou);
+        PoseEstimation[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou);
+        Dictionary<int, PoseEstimation[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou);
     }
 }

--- a/YoloDotNet/Modules/Interfaces/ISegmentationModule.cs
+++ b/YoloDotNet/Modules/Interfaces/ISegmentationModule.cs
@@ -2,7 +2,7 @@
 {
     public interface ISegmentationModule : IModule
     {
-        List<Segmentation> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou);
-        Dictionary<int, List<Segmentation>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou);
+        Segmentation[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou);
+        Dictionary<int, Segmentation[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou);
     }
 }

--- a/YoloDotNet/Modules/V10/ObjectDetectionModuleV10.cs
+++ b/YoloDotNet/Modules/V10/ObjectDetectionModuleV10.cs
@@ -18,7 +18,7 @@ namespace YoloDotNet.Modules.V10
             SubscribeToVideoEvents();
         }
 
-        public List<ObjectDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public ObjectDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
         {
             using var ortValues = _yoloCore!.Run(image);
             using var ort = ortValues[0];
@@ -28,7 +28,7 @@ namespace YoloDotNet.Modules.V10
             return [.. results];
         }
 
-        public Dictionary<int, List<ObjectDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, ObjectDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/V11/ClassificationModuleV11.cs
+++ b/YoloDotNet/Modules/V11/ClassificationModuleV11.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<Classification> ProcessImage(SKImage image, double classes, double pixelConfidence,double iou)
+        public Classification[] ProcessImage(SKImage image, double classes, double pixelConfidence,double iou)
             => _classificationModuleV8.ProcessImage(image, classes, pixelConfidence, iou);
 
-        public Dictionary<int, List<Classification>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, Classification[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/V11/OBBDetectionModuleV11.cs
+++ b/YoloDotNet/Modules/V11/OBBDetectionModuleV11.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<OBBDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public OBBDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
             => _obbDetectionModuleV8.ProcessImage(image, confidence, pixelConfidence, iou);
 
-        public Dictionary<int, List<OBBDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, OBBDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/V11/ObjectDetectionModuleV11.cs
+++ b/YoloDotNet/Modules/V11/ObjectDetectionModuleV11.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<ObjectDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public ObjectDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
             => _objectDetectionModuleV8.ProcessImage(image, confidence, pixelConfidence, iou);
 
-        public Dictionary<int, List<ObjectDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, ObjectDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         private void SubscribeToVideoEvents()

--- a/YoloDotNet/Modules/V11/PoseEstimationModuleV11.cs
+++ b/YoloDotNet/Modules/V11/PoseEstimationModuleV11.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<PoseEstimation> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public PoseEstimation[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
             => _poseEstimationModuleV8.ProcessImage(image, confidence, pixelConfidence, iou);
 
-        public Dictionary<int, List<PoseEstimation>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, PoseEstimation[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/V11/SegmentationModuleV11.cs
+++ b/YoloDotNet/Modules/V11/SegmentationModuleV11.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<Segmentation> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public Segmentation[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
             => _segmentationModuleV8.ProcessImage(image, confidence, pixelConfidence, iou);
 
-        public Dictionary<int, List<Segmentation>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, Segmentation[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/V8/ClassificationModuleV8.cs
+++ b/YoloDotNet/Modules/V8/ClassificationModuleV8.cs
@@ -20,14 +20,14 @@
             SubscribeToVideoEvents();
         }
 
-        public List<Classification> ProcessImage(SKImage image, double classes, double pixelConfidence, double iou)
+        public Classification[] ProcessImage(SKImage image, double classes, double pixelConfidence, double iou)
         {
             using var ortValues = _yoloCore.Run(image);
             using var ort = ortValues[0];
             return ClassifyTensor(ort, (int)classes);
         }
 
-        public Dictionary<int, List<Classification>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, Classification[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Classicifation
@@ -36,7 +36,7 @@
         /// Classifies a tensor and returns a Classification list 
         /// </summary>
         /// <param name="numberOfClasses"></param>
-        private List<Classification> ClassifyTensor(OrtValue ortTensor, int numberOfClasses)
+        private Classification[] ClassifyTensor(OrtValue ortTensor, int numberOfClasses)
         {
             var span = ortTensor.GetTensorDataAsSpan<float>();
             var tmp = new Classification[span.Length];

--- a/YoloDotNet/Modules/V8/OBBDetectionModuleV8.cs
+++ b/YoloDotNet/Modules/V8/OBBDetectionModuleV8.cs
@@ -18,7 +18,7 @@
             SubscribeToVideoEvents();
         }
 
-        public List<OBBDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public OBBDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
         {
             using IDisposableReadOnlyCollection<OrtValue>? ortValues = _yoloCore.Run(image);
             var ortSpan = ortValues[0].GetTensorDataAsSpan<float>();
@@ -28,7 +28,7 @@
             return [.. objectDetectionResults.Select(x => (OBBDetection)x)];
         }
 
-        public Dictionary<int, List<OBBDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, OBBDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/V8/ObjectDetectionModuleV8.cs
+++ b/YoloDotNet/Modules/V8/ObjectDetectionModuleV8.cs
@@ -31,7 +31,7 @@
             SubscribeToVideoEvents();
         }
 
-        public List<ObjectDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public ObjectDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
         {
             using var ortValues = _yoloCore.Run(image);
             var ortSpan = ortValues[0].GetTensorDataAsSpan<float>();
@@ -42,7 +42,7 @@
             return [..results];
         }
 
-        public Dictionary<int, List<ObjectDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, ObjectDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods

--- a/YoloDotNet/Modules/V8/PoseEstimationModuleV8.cs
+++ b/YoloDotNet/Modules/V8/PoseEstimationModuleV8.cs
@@ -18,7 +18,7 @@
             SubscribeToVideoEvents();
         }
 
-        public List<PoseEstimation> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public PoseEstimation[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
         {
             using IDisposableReadOnlyCollection<OrtValue>? ortValues = _yoloCore.Run(image);
             var ortSpan = ortValues[0].GetTensorDataAsSpan<float>(); ;
@@ -26,12 +26,12 @@
             return PoseEstimateImage(image, ortSpan, confidence, iou);
         }
 
-        public Dictionary<int, List<PoseEstimation>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, PoseEstimation[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Helper methods
 
-        public List<PoseEstimation> PoseEstimateImage(SKImage image, ReadOnlySpan<float> ortSpan, double threshold, double overlapThrehshold)
+        public PoseEstimation[] PoseEstimateImage(SKImage image, ReadOnlySpan<float> ortSpan, double threshold, double overlapThrehshold)
         {
             var boxes = _objectDetectionModule.ObjectDetection(image, ortSpan, threshold, overlapThrehshold);
 

--- a/YoloDotNet/Modules/V8/SegmentationModuleV8.cs
+++ b/YoloDotNet/Modules/V8/SegmentationModuleV8.cs
@@ -18,13 +18,13 @@
             SubscribeToVideoEvents();
         }
 
-        public List<Segmentation> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public Segmentation[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
         {
             using IDisposableReadOnlyCollection<OrtValue>? ortValues = _yoloCore.Run(image);
             return RunSegmentation(image, ortValues, confidence, pixelConfidence, iou);
         }
 
-        public Dictionary<int, List<Segmentation>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, Segmentation[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         #region Segmentation
@@ -60,7 +60,7 @@
         /// <param name="confidence">The confidence threshold for object detection.</param>
         /// <param name="iou">The Intersection over Union (IoU) threshold for excluding bounding boxes.</param>
         /// <returns>A list of Segmentation objects corresponding to the input bounding boxes.</returns> 
-        private List<Segmentation> RunSegmentation(SKImage image, IDisposableReadOnlyCollection<OrtValue> ortValues, double confidence, double pixelConfidence, double iou)
+        private Segmentation[] RunSegmentation(SKImage image, IDisposableReadOnlyCollection<OrtValue> ortValues, double confidence, double pixelConfidence, double iou)
         {
             var ortSpan0 = ortValues[0].GetTensorDataAsSpan<float>();
             var ortSpan1 = ortValues[1].GetTensorDataAsSpan<float>();

--- a/YoloDotNet/Modules/V9/ObjectDetectionModuleV9.cs
+++ b/YoloDotNet/Modules/V9/ObjectDetectionModuleV9.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<ObjectDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public ObjectDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
             => _objectDetectionModule.ProcessImage(image, confidence, pixelConfidence, iou);
 
-        public Dictionary<int, List<ObjectDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, ObjectDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         private void SubscribeToVideoEvents()

--- a/YoloDotNet/Modules/WorldV2/ObjectDetectionModuleWorldV2.cs
+++ b/YoloDotNet/Modules/WorldV2/ObjectDetectionModuleWorldV2.cs
@@ -22,10 +22,10 @@
             SubscribeToVideoEvents();
         }
 
-        public List<ObjectDetection> ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
+        public ObjectDetection[] ProcessImage(SKImage image, double confidence, double pixelConfidence, double iou)
             => _objectDetectionModule.ProcessImage(image, confidence, pixelConfidence, iou);
 
-        public Dictionary<int, List<ObjectDetection>> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
+        public Dictionary<int, ObjectDetection[]> ProcessVideo(VideoOptions options, double confidence, double pixelConfidence, double iou)
             => _yoloCore.RunVideo(options, confidence, pixelConfidence, iou, ProcessImage);
 
         private void SubscribeToVideoEvents()

--- a/YoloDotNet/Yolo.cs
+++ b/YoloDotNet/Yolo.cs
@@ -40,7 +40,7 @@
         /// <param name="img">The image to classify.</param>
         /// <param name="classes">The number of classes to return (default is 1).</param>
         /// <returns>A list of classification results.</returns>
-        public List<Classification> RunClassification(SKImage img, int classes = 1)
+        public Classification[] RunClassification(SKImage img, int classes = 1)
             => ((IClassificationModule)_detection).ProcessImage(img, classes, 0, 0);
 
         /// <summary>
@@ -50,7 +50,7 @@
         /// <param name="confidence">The confidence threshold for detected objects (default is 0.23).</param>
         /// <param name="iou">IoU (Intersection Over Union) overlap threshold value for removing overlapping bounding boxes (default: 0.7).</param>
         /// <returns>A list of classification results.</returns>
-        public List<ObjectDetection> RunObjectDetection(SKImage img, double confidence = 0.23, double iou = 0.7)
+        public ObjectDetection[] RunObjectDetection(SKImage img, double confidence = 0.23, double iou = 0.7)
             => ((IObjectDetectionModule)_detection).ProcessImage(img, confidence, 0, iou);
         
         /// <summary>
@@ -60,7 +60,7 @@
         /// <param name="confidence">The confidence threshold for detected objects (default is 0.23).</param>
         /// <param name="iou">IoU (Intersection Over Union) overlap threshold value for removing overlapping bounding boxes (default: 0.7).</param>
         /// <returns>A list of Segmentation results.</returns>
-        public List<OBBDetection> RunObbDetection(SKImage img, double confidence = 0.23, double iou = 0.7)
+        public OBBDetection[] RunObbDetection(SKImage img, double confidence = 0.23, double iou = 0.7)
             => ((IOBBDetectionModule)_detection).ProcessImage(img, confidence, 0, iou);
 
         /// <summary>
@@ -70,7 +70,7 @@
         /// <param name="confidence">The confidence threshold for detected objects (default is 0.23).</param>
         /// <param name="iou">IoU (Intersection Over Union) overlap threshold value for removing overlapping bounding boxes (default: 0.7).</param>
         /// <returns>A list of Segmentation results.</returns>
-        public List<Segmentation> RunSegmentation(SKImage img, double confidence = 0.23, double pixelConfedence = 0.65, double iou = 0.7)
+        public Segmentation[] RunSegmentation(SKImage img, double confidence = 0.23, double pixelConfedence = 0.65, double iou = 0.7)
             => ((ISegmentationModule)_detection).ProcessImage(img, confidence, pixelConfedence, iou);
         
         /// <summary>
@@ -80,7 +80,7 @@
         /// <param name="confidence">The confidence threshold for detected objects (default is 0.23).</param>
         /// <param name="iou">IoU (Intersection Over Union) overlap threshold value for removing overlapping bounding boxes (default: 0.7).</param>
         /// <returns>A list of Segmentation results.</returns>
-        public List<PoseEstimation> RunPoseEstimation(SKImage img, double confidence = 0.23, double iou = 0.7)
+        public PoseEstimation[] RunPoseEstimation(SKImage img, double confidence = 0.23, double iou = 0.7)
             => ((IPoseEstimationModule)_detection).ProcessImage(img, confidence, 0, iou);
 
         #endregion
@@ -92,7 +92,7 @@
         /// </summary>
         /// <param name="options">Options for video processing.</param>
         /// <param name="classes">The number of classes to return for each frame (default is 1).</param>
-        public Dictionary<int, List<Classification>> RunClassification(VideoOptions options, int classes = 1)
+        public Dictionary<int, Classification[]> RunClassification(VideoOptions options, int classes = 1)
             => ((IClassificationModule)_detection).ProcessVideo(options, classes, 0, 0);
 
         /// <summary>
@@ -101,7 +101,7 @@
         /// <param name="options">Options for video processing.</param>
         /// <param name="confidence">The confidence threshold for detected objects (default is 0.23).</param>
         /// <param name="iou">IoU (Intersection Over Union) overlap threshold value for removing overlapping bounding boxes (default: 0.7).</param>
-        public Dictionary<int, List<ObjectDetection>> RunObjectDetection(VideoOptions options, double confidence = 0.23, double iou = 0.7)
+        public Dictionary<int, ObjectDetection[]> RunObjectDetection(VideoOptions options, double confidence = 0.23, double iou = 0.7)
             => ((IObjectDetectionModule)_detection).ProcessVideo(options, confidence, 0, iou);  //((ObjectDetectionModule)_detection).ProcessVideo(options, confidence, iou);
         
         /// <summary>
@@ -110,7 +110,7 @@
         /// <param name="options">Options for video processing.</param>
         /// <param name="confidence">The confidence threshold for detected objects (default is 0.23).</param>
         /// <param name="iou">IoU (Intersection Over Union) overlap threshold value for removing overlapping bounding boxes (default: 0.7).</param>
-        public Dictionary<int, List<OBBDetection>> RunObbDetection(VideoOptions options, double confidence = 0.23, double iou = 0.7)
+        public Dictionary<int, OBBDetection[]> RunObbDetection(VideoOptions options, double confidence = 0.23, double iou = 0.7)
             => ((IOBBDetectionModule)_detection).ProcessVideo(options, confidence, 0, iou);
 
         /// <summary>
@@ -119,7 +119,7 @@
         /// <param name="options">Options for video processing.</param>
         /// <param name="confidence">The confidence threshold for detected objects (default is 0.23).</param>
         /// <param name="iou">IoU (Intersection Over Union) overlap threshold value for removing overlapping bounding boxes (default: 0.7).</param>
-        public Dictionary<int, List<Segmentation>> RunSegmentation(VideoOptions options, double confidence = 0.23, double pixelConfidence = 0.65, double iou = 0.7)
+        public Dictionary<int, Segmentation[]> RunSegmentation(VideoOptions options, double confidence = 0.23, double pixelConfidence = 0.65, double iou = 0.7)
             => ((ISegmentationModule)_detection).ProcessVideo(options, confidence, pixelConfidence, iou);
 
         /// <summary>
@@ -128,7 +128,7 @@
         /// <param name="options">Options for video processing.</param>
         /// <param name="confidence">The confidence threshold for detected objects (default is 0.23).</param>
         /// <param name="iou">IoU (Intersection Over Union) overlap threshold value for removing overlapping bounding boxes (default: 0.7).</param>
-        public Dictionary<int, List<PoseEstimation>> RunPoseEstimation(VideoOptions options, double confidence = 0.23, double iou = 0.7)
+        public Dictionary<int, PoseEstimation[]> RunPoseEstimation(VideoOptions options, double confidence = 0.23, double iou = 0.7)
             => ((IPoseEstimationModule)_detection).ProcessVideo(options, confidence, 0, iou);
 
         public void Dispose()

--- a/test/YoloDotNet.Benchmarks/ImageExtensionTests/ClassificationImageDrawTests.cs
+++ b/test/YoloDotNet.Benchmarks/ImageExtensionTests/ClassificationImageDrawTests.cs
@@ -10,7 +10,7 @@
 
         private Yolo _cpuYolo;
         private SKImage _image;
-        private List<Classification> _classifications;
+        private Classification[] _classifications;
 
         #endregion Fields
 

--- a/test/YoloDotNet.Benchmarks/ImageExtensionTests/ObjectDetectionImageDrawTests.cs
+++ b/test/YoloDotNet.Benchmarks/ImageExtensionTests/ObjectDetectionImageDrawTests.cs
@@ -10,7 +10,7 @@
 
         private Yolo _cpuYolo;
         private SKImage _image;
-        private List<ObjectDetection> _objectDetections;
+        private ObjectDetection[] _objectDetections;
 
         #endregion Fields
 

--- a/test/YoloDotNet.Benchmarks/ImageExtensionTests/OrientedBoundingBoxImageDrawTests.cs
+++ b/test/YoloDotNet.Benchmarks/ImageExtensionTests/OrientedBoundingBoxImageDrawTests.cs
@@ -10,7 +10,7 @@
 
         private Yolo _cpuYolo;
         private SKImage _image;
-        private List<OBBDetection> _oBBDetections;
+        private OBBDetection[] _oBBDetections;
 
         #endregion Fields
 

--- a/test/YoloDotNet.Benchmarks/ImageExtensionTests/PoseEstimationImageDrawTests.cs
+++ b/test/YoloDotNet.Benchmarks/ImageExtensionTests/PoseEstimationImageDrawTests.cs
@@ -10,7 +10,7 @@
 
         private Yolo _cpuYolo;
         private SKImage _image;
-        private List<PoseEstimation> _poseEstimations;
+        private PoseEstimation[] _poseEstimations;
 
         #endregion Fields
 

--- a/test/YoloDotNet.Benchmarks/ImageExtensionTests/SegmentationImageDrawTests.cs
+++ b/test/YoloDotNet.Benchmarks/ImageExtensionTests/SegmentationImageDrawTests.cs
@@ -10,7 +10,7 @@
 
         private Yolo _cpuYolo;
         private SKImage _image;
-        private List<Segmentation> _segmentations;
+        private Segmentation[] _segmentations;
 
         #endregion Fields
 

--- a/test/YoloDotNet.Benchmarks/ObjectDetectionTests/ResizeSourceObjectDetectionTests.cs
+++ b/test/YoloDotNet.Benchmarks/ObjectDetectionTests/ResizeSourceObjectDetectionTests.cs
@@ -47,25 +47,25 @@
         }
 
         [Benchmark]
-        public List<ObjectDetection> ObjectDetectionOriginalSizeCpu()
+        public ObjectDetection[] ObjectDetectionOriginalSizeCpu()
         {
             return _cpuYolo.RunObjectDetection(_originalSizeimage);
         }
 
         [Benchmark]
-        public List<ObjectDetection> ObjectDetectionOriginalSizeGpu()
+        public ObjectDetection[] ObjectDetectionOriginalSizeGpu()
         {
             return _cudaYolo.RunObjectDetection(_originalSizeimage);
         }
 
         [Benchmark]
-        public List<ObjectDetection> ObjectDetectionModelSizeCpu()
+        public ObjectDetection[] ObjectDetectionModelSizeCpu()
         {
             return _cpuYolo.RunObjectDetection(_modelSizeImage);
         }
 
         [Benchmark]
-        public List<ObjectDetection> ObjectDetectionModelSizeGpu()
+        public ObjectDetection[] ObjectDetectionModelSizeGpu()
         {
             return _cudaYolo.RunObjectDetection(_modelSizeImage);
         }

--- a/test/YoloDotNet.Benchmarks/OrientedBoundingBoxTests/SimpleOrientedBoundingBoxTests.cs
+++ b/test/YoloDotNet.Benchmarks/OrientedBoundingBoxTests/SimpleOrientedBoundingBoxTests.cs
@@ -62,26 +62,26 @@
 
         // Yolov8
         [Benchmark]
-        public List<OBBDetection> RunSimpleObbDetectionYolov8Cpu()
+        public OBBDetection[] RunSimpleObbDetectionYolov8Cpu()
         {
             return _cpuYolov8.RunObbDetection(_image);
         }
 
         [Benchmark]
-        public List<OBBDetection> RunSimpleObbDetectionYolov8Gpu()
+        public OBBDetection[] RunSimpleObbDetectionYolov8Gpu()
         {
             return _gpuYolov8.RunObbDetection(_image);
         }
 
         // Yolov11
         [Benchmark]
-        public List<OBBDetection> RunSimpleObbDetectionYolov11Cpu()
+        public OBBDetection[] RunSimpleObbDetectionYolov11Cpu()
         {
             return _cpuYolov11.RunObbDetection(_image);
         }
 
         [Benchmark]
-        public List<OBBDetection> RunSimpleObbDetectionYolov11Gpu()
+        public OBBDetection[] RunSimpleObbDetectionYolov11Gpu()
         {
             return _gpuYolov11.RunObbDetection(_image);
         }

--- a/test/YoloDotNet.Benchmarks/PoseEstimationTests/SimplePoseEstimationTests.cs
+++ b/test/YoloDotNet.Benchmarks/PoseEstimationTests/SimplePoseEstimationTests.cs
@@ -62,26 +62,26 @@
 
         // Yolov8
         [Benchmark]
-        public List<PoseEstimation> RunSimplePoseEstimationYolov8Cpu()
+        public PoseEstimation[] RunSimplePoseEstimationYolov8Cpu()
         {
             return _cpuYolov8.RunPoseEstimation(_image);
         }
 
         [Benchmark]
-        public List<PoseEstimation> RunSimplePoseEstimationYolov8Gpu()
+        public PoseEstimation[] RunSimplePoseEstimationYolov8Gpu()
         {
             return _gpuYolov8.RunPoseEstimation(_image);
         }
 
         // Yolov11
         [Benchmark]
-        public List<PoseEstimation> RunSimplePoseEstimationYolov11Cpu()
+        public PoseEstimation[] RunSimplePoseEstimationYolov11Cpu()
         {
             return _cpuYolov11.RunPoseEstimation(_image);
         }
 
         [Benchmark]
-        public List<PoseEstimation> RunSimplePoseEstimationYolov11Gpu()
+        public PoseEstimation[] RunSimplePoseEstimationYolov11Gpu()
         {
             return _gpuYolov11.RunPoseEstimation(_image);
         }

--- a/test/YoloDotNet.Benchmarks/SegmentationTests/SimpleSegmentationTests.cs
+++ b/test/YoloDotNet.Benchmarks/SegmentationTests/SimpleSegmentationTests.cs
@@ -62,26 +62,26 @@
 
         // Yolov8
         [Benchmark]
-        public List<Segmentation> RunSimpleSegmentationYolov8Cpu()
+        public Segmentation[] RunSimpleSegmentationYolov8Cpu()
         {
             return _cpuYolov8.RunSegmentation(_image);
         }
 
         [Benchmark]
-        public List<Segmentation> RunSimpleSegmentationYolov8Gpu()
+        public Segmentation[] RunSimpleSegmentationYolov8Gpu()
         {
             return _gpuYolov8.RunSegmentation(_image);
         }
 
         // Yolov11
         [Benchmark]
-        public List<Segmentation> RunSimpleSegmentationYolov11Cpu()
+        public Segmentation[] RunSimpleSegmentationYolov11Cpu()
         {
             return _cpuYolov11.RunSegmentation(_image);
         }
 
         [Benchmark]
-        public List<Segmentation> RunSimpleSegmentationYolov11Gpu()
+        public Segmentation[] RunSimpleSegmentationYolov11Gpu()
         {
             return _gpuYolov11.RunSegmentation(_image);
         }

--- a/test/YoloDotNet.Tests/OBBDetectionTests/Yolov11OBBDetectionTests.cs
+++ b/test/YoloDotNet.Tests/OBBDetectionTests/Yolov11OBBDetectionTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunObbDetection(image, 0.25, 0.45);
 
             // Assert
-            Assert.Equal(5, results.Count);
+            Assert.Equal(5, results.Length);
         }
     }
 }

--- a/test/YoloDotNet.Tests/OBBDetectionTests/Yolov8OBBDetectionTests.cs
+++ b/test/YoloDotNet.Tests/OBBDetectionTests/Yolov8OBBDetectionTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunObbDetection(image, 0.25, 0.45);
 
             // Assert
-            Assert.Equal(5, results.Count);
+            Assert.Equal(5, results.Length);
         }
     }
 }

--- a/test/YoloDotNet.Tests/ObjectDetectionTests/Yolov10ObjectDetectionTests.cs
+++ b/test/YoloDotNet.Tests/ObjectDetectionTests/Yolov10ObjectDetectionTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunObjectDetection(image);
 
             // Assert
-            Assert.Equal(29, results.Count);
+            Assert.Equal(29, results.Length);
         }
     }
 }

--- a/test/YoloDotNet.Tests/ObjectDetectionTests/Yolov11ObjectDetectionTests.cs
+++ b/test/YoloDotNet.Tests/ObjectDetectionTests/Yolov11ObjectDetectionTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunObjectDetection(image);
 
             // Assert
-            Assert.Equal(30, results.Count);
+            Assert.Equal(30, results.Length);
         }
     }
 }

--- a/test/YoloDotNet.Tests/ObjectDetectionTests/Yolov12ObjectDetectionTests.cs
+++ b/test/YoloDotNet.Tests/ObjectDetectionTests/Yolov12ObjectDetectionTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunObjectDetection(image);
 
             // Assert
-            Assert.Equal(31, results.Count);
+            Assert.Equal(31, results.Length);
         }
     }
 }

--- a/test/YoloDotNet.Tests/ObjectDetectionTests/Yolov8ObjectDetectionTests.cs
+++ b/test/YoloDotNet.Tests/ObjectDetectionTests/Yolov8ObjectDetectionTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunObjectDetection(image);
 
             // Assert
-            Assert.Equal(33, results.Count);
+            Assert.Equal(33, results.Length);
         }
     }
 }

--- a/test/YoloDotNet.Tests/ObjectDetectionTests/Yolov9ObjectDetectionTests.cs
+++ b/test/YoloDotNet.Tests/ObjectDetectionTests/Yolov9ObjectDetectionTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunObjectDetection(image);
 
             // Assert
-            Assert.Equal(28, results.Count);
+            Assert.Equal(28, results.Length);
         }
     }
 }

--- a/test/YoloDotNet.Tests/PoseEstimationTests/Yolov11PoseEstimationTests.cs
+++ b/test/YoloDotNet.Tests/PoseEstimationTests/Yolov11PoseEstimationTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunPoseEstimation(image);
 
             // Assert
-            Assert.Equal(10, results.Count);
+            Assert.Equal(10, results.Length);
         }
     }
 }

--- a/test/YoloDotNet.Tests/PoseEstimationTests/Yolov8PoseEstimationTests.cs
+++ b/test/YoloDotNet.Tests/PoseEstimationTests/Yolov8PoseEstimationTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunPoseEstimation(image, 0.25, 0.45);
 
             // Assert
-            Assert.Equal(10, results.Count);
+            Assert.Equal(10, results.Length);
         }
     }
 }

--- a/test/YoloDotNet.Tests/SegmentationTests/Yolov11SegmentationTests.cs
+++ b/test/YoloDotNet.Tests/SegmentationTests/Yolov11SegmentationTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunSegmentation(image);
 
             // Assert
-            Assert.Equal(17, results.Count);
+            Assert.Equal(17, results.Length);
         }
     }
 }

--- a/test/YoloDotNet.Tests/SegmentationTests/Yolov8SegmentationTests.cs
+++ b/test/YoloDotNet.Tests/SegmentationTests/Yolov8SegmentationTests.cs
@@ -22,7 +22,7 @@
             var results = yolo.RunSegmentation(image);
 
             // Assert
-            Assert.Equal(21, results.Count);
+            Assert.Equal(21, results.Length);
         }
     }
 }


### PR DESCRIPTION
Reduce allocations in the following ways

1. Structs to replace classes
2. Use Array<T> not List<T>
3. Prevent boxing to an interface

These are the results from my computer.

Starting Values:

| Method                    | Mean     | Error    | StdDev   | Allocated |
|-------------------------- |---------:|---------:|---------:|----------:|
| ObjectDetectionYolov8Cpu  | 66.22 ms | 1.754 ms | 5.173 ms |  34.48 KB |
| ObjectDetectionYolov8Gpu  | 11.64 ms | 0.174 ms | 0.145 ms |  34.48 KB |
| ObjectDetectionYolov9Cpu  | 67.42 ms | 1.263 ms | 2.403 ms |   29.4 KB |
| ObjectDetectionYolov9Gpu  | 17.66 ms | 0.044 ms | 0.039 ms |  29.33 KB |
| ObjectDetectionYolov10Cpu | 65.90 ms | 1.303 ms | 3.197 ms |  24.26 KB |
| ObjectDetectionYolov10Gpu | 10.35 ms | 0.041 ms | 0.034 ms |   24.2 KB |
| ObjectDetectionYolov11Cpu | 71.02 ms | 0.643 ms | 0.570 ms |  32.65 KB |
| ObjectDetectionYolov11Gpu | 11.59 ms | 0.035 ms | 0.031 ms |  32.58 KB |
| ObjectDetectionYolov12Cpu | 85.72 ms | 1.706 ms | 3.598 ms |  31.05 KB |
| ObjectDetectionYolov12Gpu | 13.82 ms | 0.075 ms | 0.066 ms |  30.96 KB |

Ending Values: 

| Method                    | Mean     | Error    | StdDev   | Allocated |
|-------------------------- |---------:|---------:|---------:|----------:|
| ObjectDetectionYolov8Cpu  | 62.00 ms | 1.223 ms | 2.110 ms |  27.99 KB |
| ObjectDetectionYolov8Gpu  | 11.55 ms | 0.019 ms | 0.016 ms |  27.93 KB |
| ObjectDetectionYolov9Cpu  | 65.64 ms | 1.284 ms | 1.319 ms |   23.9 KB |
| ObjectDetectionYolov9Gpu  | 17.63 ms | 0.084 ms | 0.079 ms |  23.83 KB |
| ObjectDetectionYolov10Cpu | 54.61 ms | 0.884 ms | 0.784 ms |  22.21 KB |
| ObjectDetectionYolov10Gpu | 10.39 ms | 0.100 ms | 0.094 ms |  22.14 KB |
| ObjectDetectionYolov11Cpu | 61.14 ms | 1.212 ms | 2.123 ms |  26.52 KB |
| ObjectDetectionYolov11Gpu | 11.56 ms | 0.064 ms | 0.056 ms |  26.45 KB |
| ObjectDetectionYolov12Cpu | 73.53 ms | 1.416 ms | 1.325 ms |  25.17 KB |
| ObjectDetectionYolov12Gpu | 13.68 ms | 0.057 ms | 0.053 ms |  25.08 KB |

The benchmarks only run the method once, so the GC impact is not showing.
This is something that can be added in future.

All tests passing.
Demo's still work as intended.