### PR TITLE
Change parameter type from dynamic to object

### DIFF
--- a/YoloDotNet/Extensions/OnnxPropertiesExtension.cs
+++ b/YoloDotNet/Extensions/OnnxPropertiesExtension.cs
@@ -66,7 +66,7 @@ namespace YoloDotNet.Extensions
             })];
         }
 
-        private static string NameOf(dynamic metadata)
+        private static string NameOf(object metadata)
             => metadata.ToString().ToLower();
 
         /// <summary>


### PR DESCRIPTION
dynamic is unnecessary.  We need `object` type to support Native AOT.